### PR TITLE
Check to see if the Google provider has been added

### DIFF
--- a/OauthExternalAuthentication/OAuthAuthenticationModule.cs
+++ b/OauthExternalAuthentication/OAuthAuthenticationModule.cs
@@ -97,7 +97,6 @@ namespace OauthExternalAuthentication
             //Google
             if (!String.IsNullOrEmpty(oaeConfig.GoogleClientID) && !String.IsNullOrEmpty(oaeConfig.GoogleClientSecret))
             {
-                //if(OpenAuth.AuthenticationClients.GetByProviderName("Google") == null)
                  ProviderDetails googleClient = OpenAuth.AuthenticationClients.GetAll().FirstOrDefault(client => client.ProviderName.ToLower() == "google");
                  if (googleClient == null)
                  {

--- a/OauthExternalAuthentication/OAuthAuthenticationModule.cs
+++ b/OauthExternalAuthentication/OAuthAuthenticationModule.cs
@@ -97,7 +97,12 @@ namespace OauthExternalAuthentication
             //Google
             if (!String.IsNullOrEmpty(oaeConfig.GoogleClientID) && !String.IsNullOrEmpty(oaeConfig.GoogleClientSecret))
             {
-                OpenAuth.AuthenticationClients.Add("Google", () => new GoogleOAuth2Client(oaeConfig.GoogleClientID, oaeConfig.GoogleClientSecret));﻿
+                //if(OpenAuth.AuthenticationClients.GetByProviderName("Google") == null)
+                 ProviderDetails googleClient = OpenAuth.AuthenticationClients.GetAll().FirstOrDefault(client => client.ProviderName.ToLower() == "google");
+                 if (googleClient == null)
+                 {
+                     OpenAuth.AuthenticationClients.Add("Google", () => new GoogleOAuth2Client(oaeConfig.GoogleClientID, oaeConfig.GoogleClientSecret));﻿
+                 }
             }
             //Amazon
             if (!String.IsNullOrEmpty(oaeConfig.AmazonAPPID) && !String.IsNullOrEmpty(oaeConfig.AmazonAPPSecretKey))


### PR DESCRIPTION
Without this check when you enable\disable a module from /Sitefinity/Administration/ModulesAndServices it throws key has already been added popups, and the SF instance needs an apppool recycle to come back.